### PR TITLE
Upgrade to ocp 4.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .idea/
 *.iml
 .vscode/
+.factorypath

--- a/01-deploy-infra.sh
+++ b/01-deploy-infra.sh
@@ -113,9 +113,10 @@ echo "**********************************"
 echo "Deploying Kafka Connect Cluster"
 echo "**********************************"
 
-oc apply -f 06-kafka-connect/eda-kafka-connect-is.yaml 
+oc apply -f 06-kafka-connect/eda-kafka-connect-is.yaml
+oc apply -f 06-kafka-connect/topics/
 oc apply -f 06-kafka-connect/configmap/
-oc apply -f 06-kafka-connect/eda-kafka-connect.yaml 
+oc apply -f 06-kafka-connect/eda-kafka-connect.yaml
 
 # TODO Add checks to move to next step
 sleep 300

--- a/01-operators/README.md
+++ b/01-operators/README.md
@@ -23,7 +23,7 @@ from any namespaces in the cluster.
 ```shell
 ❯ oc get pod -n openshift-operators
 NAME                                                  READY   STATUS    RESTARTS   AGE
-amq-streams-cluster-operator-v1.7.1-bcf69549b-ntdm2   1/1     Running   0          25h
+amq-streams-cluster-operator-v1.8.0-75f8c6f46c-s7mcb  1/1     Running   0          25h
 apicurio-registry-operator-576d45bbd9-jqdcb           1/1     Running   0          2m36s
 infinispan-operator-5c77fcfbc9-wg4ws                  1/1     Running   0          2m40s
 knative-openshift-9d6b46dcf-2dfdz                     1/1     Running   0          27h
@@ -36,10 +36,10 @@ To check the subscription statuses:
 ```shell
 ❯ oc get csv
 NAME                               DISPLAY                                           VERSION   REPLACES                      PHASE
-amqstreams.v1.7.2                  Red Hat Integration - AMQ Streams                 1.7.2     amqstreams.v1.7.1             Succeeded
-datagrid-operator.v8.2.0           Data Grid                                         8.2.0     datagrid-operator.v8.1.7      Succeeded
-serverless-operator.v1.15.0        Red Hat OpenShift Serverless                      1.15.0    serverless-operator.v1.14.0   Succeeded
-service-registry-operator.v2.0.0   Red Hat Integration - Service Registry Operator   2.0.0                                   Succeeded
+amqstreams.v1.8.0                  Red Hat Integration - AMQ Streams                 1.8.0     amqstreams.v1.7.3                  Succeeded
+datagrid-operator.v8.2.3           Data Grid                                         8.2.3     datagrid-operator.v8.2.2           Succeeded
+serverless-operator.v1.16.0        Red Hat OpenShift Serverless                      1.16.0    serverless-operator.v1.15.0        Succeeded
+service-registry-operator.v2.0.1   Red Hat Integration - Service Registry Operator   2.0.1     service-registry-operator.v2.0.0   Succeeded
 ```
 
 ## Local Operators
@@ -65,6 +65,6 @@ To check the subscription statuses:
 ```shell
 ❯ oc get csv
 NAME                               DISPLAY                VERSION   REPLACES                      PHASE
-grafana-operator.v3.10.1           Grafana Operator       3.10.1    grafana-operator.v3.10.0      Succeeded
+grafana-operator.v3.10.2           Grafana Operator       3.10.2    grafana-operator.v3.10.1      Succeeded
 prometheusoperator.0.47.0          Prometheus Operator    0.47.0    prometheusoperator.0.37.0     Succeeded
 ```

--- a/01-operators/cluster-wide/amq-streams-subscription.yml
+++ b/01-operators/cluster-wide/amq-streams-subscription.yml
@@ -10,4 +10,4 @@ spec:
   name: amq-streams
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: amqstreams.v1.7.2
+  startingCSV: amqstreams.v1.8.0

--- a/01-operators/cluster-wide/datagrid-subscription.yml
+++ b/01-operators/cluster-wide/datagrid-subscription.yml
@@ -10,4 +10,4 @@ spec:
   name: datagrid
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: datagrid-operator.v8.2.0
+  startingCSV: datagrid-operator.v8.2.3

--- a/01-operators/cluster-wide/serverless-operator-subscription.yaml
+++ b/01-operators/cluster-wide/serverless-operator-subscription.yaml
@@ -10,4 +10,4 @@ spec:
   name: serverless-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: serverless-operator.v1.15.0
+  startingCSV: serverless-operator.v1.16.0

--- a/01-operators/cluster-wide/service-registry-operator-subscription.yml
+++ b/01-operators/cluster-wide/service-registry-operator-subscription.yml
@@ -10,4 +10,4 @@ spec:
   name: service-registry-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: service-registry-operator.v2.0.0
+  startingCSV: service-registry-operator.v2.0.1

--- a/02-deploy-apps.sh
+++ b/02-deploy-apps.sh
@@ -36,3 +36,14 @@ echo "**********************************"
 oc new-app registry.access.redhat.com/ubi8/openjdk-11~https://github.com/atarazana/eda-workshop.git \
     --context-dir=12-quarkus-dashboard --name dashboard
 oc expose svc/dashboard
+
+sleep 420
+
+echo "**********************************"
+echo "Tagging Application Images"
+echo "**********************************"
+
+oc tag business-app:latest business-app:2.1.3-SNAPSHOT
+oc tag data-streaming:latest data-streaming:2.1.3-SNAPSHOT
+oc tag backend:latest backend:2.1.3-SNAPSHOT
+oc tag dashboard:latest dashboard:2.1.3-SNAPSHOT

--- a/04-kafka/kafka/event-bus-kafka.yml
+++ b/04-kafka/kafka/event-bus-kafka.yml
@@ -1,3 +1,4 @@
+---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
@@ -6,10 +7,11 @@ metadata:
   name: event-bus
 spec:
   kafka:
-    version: 2.7.0
+    version: 2.8.0
     config:
       # Log message format
-      log.message.format.version: "2.7"
+      log.message.format.version: 2.8
+      inter.broker.protocol.version: 2.8
       # default replication factors for automatically created topics
       default.replication.factor: 3
       # The default number of log partitions per topic
@@ -76,7 +78,7 @@ spec:
         cpu: 500m
       limits:
         memory: 2Gi
-        cpu: "1"
+        cpu: 1
     storage:
       type: jbod
       volumes:
@@ -121,7 +123,7 @@ spec:
         cpu: 500m
       limits:
         memory: 2Gi
-        cpu: "1"
+        cpu: 1
     storage:
       type: persistent-claim
       deleteClaim: true
@@ -162,16 +164,6 @@ spec:
       #  limits:
       #    cpu: 1
       #    memory: 1Gi
-  kafkaExporter:
-    groupRegex: .*
-    topicRegex: .*
-    #resources:
-    #  requests:
-    #    cpu: 250m
-    #    memory: 1Gi
-    #  limits:
-    #    cpu: 1
-    #    memory: 1Gi
   clientsCa:
     generateCertificateAuthority: true
     renewalDays: 30
@@ -181,14 +173,8 @@ spec:
     renewalDays: 30
     validityDays: 1460
   kafkaExporter:
-    topicRegex: ".*"
-    groupRegex: ".*"
-    readinessProbe:
-      initialDelaySeconds: 15
-      timeoutSeconds: 5
-    livenessProbe:
-      initialDelaySeconds: 15
-      timeoutSeconds: 5
+    topicRegex: .*
+    groupRegex: .*
     #resources:
     #  requests:
     #    cpu: 250m
@@ -196,6 +182,12 @@ spec:
     #  limits:
     #    cpu: 1
     #    memory: 1Gi
+    readinessProbe:
+      initialDelaySeconds: 15
+      timeoutSeconds: 5
+    livenessProbe:
+      initialDelaySeconds: 15
+      timeoutSeconds: 5
   #cruiseControl:
   #  #brokerCapacity:
   #  #  inboundNetwork: 10000KB/s

--- a/04-kafka/topics/data/eda-data-accounts-topic.yml
+++ b/04-kafka/topics/data/eda-data-accounts-topic.yml
@@ -1,4 +1,5 @@
-apiVersion: kafka.strimzi.io/v1beta1
+---
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   labels:
@@ -7,8 +8,8 @@ metadata:
 spec:
   config:
     # 7 days
-    retention.ms: "604800000"
-    segment.bytes: "1073741824"
-    cleanup.policy: "compact"
+    retention.ms: 604800000
+    segment.bytes: 1073741824
+    cleanup.policy: compact
   partitions: 1
   replicas: 3

--- a/04-kafka/topics/data/eda-data-clients-topic.yml
+++ b/04-kafka/topics/data/eda-data-clients-topic.yml
@@ -1,4 +1,5 @@
-apiVersion: kafka.strimzi.io/v1beta1
+---
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   labels:
@@ -7,8 +8,8 @@ metadata:
 spec:
   config:
     # 7 days
-    retention.ms: "604800000"
-    segment.bytes: "1073741824"
-    cleanup.policy: "compact"
+    retention.ms: 604800000
+    segment.bytes: 1073741824
+    cleanup.policy: compact
   partitions: 1
   replicas: 3

--- a/04-kafka/topics/data/eda-data-movements-topic.yml
+++ b/04-kafka/topics/data/eda-data-movements-topic.yml
@@ -1,4 +1,5 @@
-apiVersion: kafka.strimzi.io/v1beta1
+---
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   labels:
@@ -7,8 +8,8 @@ metadata:
 spec:
   config:
     # 7 days
-    retention.ms: "604800000"
-    segment.bytes: "1073741824"
-    cleanup.policy: "compact"
+    retention.ms: 604800000
+    segment.bytes: 1073741824
+    cleanup.policy: compact
   partitions: 1
   replicas: 3

--- a/04-kafka/topics/data/eda-data-regions-topic.yml
+++ b/04-kafka/topics/data/eda-data-regions-topic.yml
@@ -1,4 +1,5 @@
-apiVersion: kafka.strimzi.io/v1beta1
+---
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   labels:

--- a/04-kafka/topics/domain/eda-events-domain-accounts-balance-low-reached-topic.yml
+++ b/04-kafka/topics/domain/eda-events-domain-accounts-balance-low-reached-topic.yml
@@ -1,4 +1,5 @@
-apiVersion: kafka.strimzi.io/v1beta1
+---
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   labels:
@@ -7,8 +8,8 @@ metadata:
 spec:
   config:
     # 7 days
-    retention.ms: "604800000"
-    segment.bytes: "1073741824"
+    retention.ms: 604800000
+    segment.bytes: 1073741824
     cleanup.policy: compact
   partitions: 1
   replicas: 3

--- a/04-kafka/topics/domain/eda-events-domain-accounts-balance-neg-reached-topic.yml
+++ b/04-kafka/topics/domain/eda-events-domain-accounts-balance-neg-reached-topic.yml
@@ -1,4 +1,5 @@
-apiVersion: kafka.strimzi.io/v1beta1
+---
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   labels:
@@ -7,8 +8,8 @@ metadata:
 spec:
   config:
     # 7 days
-    retention.ms: "604800000"
-    segment.bytes: "1073741824"
+    retention.ms: 604800000
+    segment.bytes: 1073741824
     cleanup.policy: compact
   partitions: 1
   replicas: 3

--- a/04-kafka/topics/domain/eda-events-domain-accounts-balance-vip-reached-topic.yml
+++ b/04-kafka/topics/domain/eda-events-domain-accounts-balance-vip-reached-topic.yml
@@ -1,4 +1,5 @@
-apiVersion: kafka.strimzi.io/v1beta1
+---
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   labels:
@@ -7,8 +8,8 @@ metadata:
 spec:
   config:
     # 7 days
-    retention.ms: "604800000"
-    segment.bytes: "1073741824"
+    retention.ms: 604800000
+    segment.bytes: 1073741824
     cleanup.policy: compact
   partitions: 1
   replicas: 3

--- a/04-kafka/topics/domain/eda-events-domain-accounts-topic.yml
+++ b/04-kafka/topics/domain/eda-events-domain-accounts-topic.yml
@@ -1,4 +1,5 @@
-apiVersion: kafka.strimzi.io/v1beta1
+---
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   labels:
@@ -7,8 +8,8 @@ metadata:
 spec:
   config:
     # 7 days
-    retention.ms: "604800000"
-    segment.bytes: "1073741824"
+    retention.ms: 604800000
+    segment.bytes: 1073741824
     cleanup.policy: compact
   partitions: 1
   replicas: 3

--- a/04-kafka/topics/domain/eda-events-domain-clients-accounts-closed-topic.yml
+++ b/04-kafka/topics/domain/eda-events-domain-clients-accounts-closed-topic.yml
@@ -1,4 +1,5 @@
-apiVersion: kafka.strimzi.io/v1beta1
+---
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   labels:
@@ -7,8 +8,8 @@ metadata:
 spec:
   config:
     # 7 days
-    retention.ms: "604800000"
-    segment.bytes: "1073741824"
+    retention.ms: 604800000
+    segment.bytes: 1073741824
     cleanup.policy: compact
   partitions: 1
   replicas: 3

--- a/04-kafka/topics/domain/eda-events-domain-clients-accounts-inactivated-topic.yml
+++ b/04-kafka/topics/domain/eda-events-domain-clients-accounts-inactivated-topic.yml
@@ -1,4 +1,5 @@
-apiVersion: kafka.strimzi.io/v1beta1
+---
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   labels:
@@ -7,8 +8,8 @@ metadata:
 spec:
   config:
     # 7 days
-    retention.ms: "604800000"
-    segment.bytes: "1073741824"
+    retention.ms: 604800000
+    segment.bytes: 1073741824
     cleanup.policy: compact
   partitions: 1
   replicas: 3

--- a/04-kafka/topics/domain/eda-events-domain-clients-topic.yml
+++ b/04-kafka/topics/domain/eda-events-domain-clients-topic.yml
@@ -1,4 +1,5 @@
-apiVersion: kafka.strimzi.io/v1beta1
+---
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   labels:
@@ -7,8 +8,8 @@ metadata:
 spec:
   config:
     # 7 days
-    retention.ms: "604800000"
-    segment.bytes: "1073741824"
+    retention.ms: 604800000
+    segment.bytes: 1073741824
     cleanup.policy: compact
   partitions: 1
   replicas: 3

--- a/04-kafka/topics/domain/eda-events-domain-regions-topic.yml
+++ b/04-kafka/topics/domain/eda-events-domain-regions-topic.yml
@@ -1,4 +1,5 @@
-apiVersion: kafka.strimzi.io/v1beta1
+---
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   labels:
@@ -7,8 +8,8 @@ metadata:
 spec:
   config:
     # 7 days
-    retention.ms: "604800000"
-    segment.bytes: "1073741824"
+    retention.ms: 604800000
+    segment.bytes: 1073741824
     cleanup.policy: compact
   partitions: 1
   replicas: 3

--- a/04-kafka/topics/eda-events-clients-created-topic.yml
+++ b/04-kafka/topics/eda-events-clients-created-topic.yml
@@ -1,4 +1,5 @@
-apiVersion: kafka.strimzi.io/v1beta1
+---
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   labels:
@@ -7,8 +8,8 @@ metadata:
 spec:
   config:
     # 7 days
-    retention.ms: "604800000"
-    segment.bytes: "1073741824"
-    cleanup.policy: "compact"
+    retention.ms: 604800000
+    segment.bytes: 1073741824
+    cleanup.policy: compact
   partitions: 1
   replicas: 3

--- a/04-kafka/topics/eda-streaming-accounts-latest-topic.yml
+++ b/04-kafka/topics/eda-streaming-accounts-latest-topic.yml
@@ -1,4 +1,5 @@
-apiVersion: kafka.strimzi.io/v1beta1
+---
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   labels:
@@ -7,8 +8,8 @@ metadata:
 spec:
   config:
     # 7 days
-    retention.ms: "604800000"
-    segment.bytes: "1073741824"
-    cleanup.policy: "delete"
+    retention.ms: 604800000
+    segment.bytes: 1073741824
+    cleanup.policy: delete
   partitions: 1
   replicas: 3

--- a/04-kafka/topics/events/eda-events-aggregate-metrics-topic.yml
+++ b/04-kafka/topics/events/eda-events-aggregate-metrics-topic.yml
@@ -1,4 +1,5 @@
-apiVersion: kafka.strimzi.io/v1beta1
+---
+apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaTopic
 metadata:
   labels:
@@ -6,8 +7,8 @@ metadata:
   name: eda.events.aggregate-metrics
 spec:
   config:
-    retention.ms: "604800000"
-    segment.bytes: "1073741824"
-    cleanup.policy: "delete"
+    retention.ms: 604800000
+    segment.bytes: 1073741824
+    cleanup.policy: delete
   partitions: 1
   replicas: 3

--- a/06-kafka-connect/README.md
+++ b/06-kafka-connect/README.md
@@ -12,6 +12,7 @@ using the build capabilities of Red Hat AMQ Streams.
 To deploy Kafka Connect cluster exposing metrics:
 
 ```shell
+❯ oc apply -f topics/
 ❯ oc apply -f configmap/
 ❯ oc apply -f eda-kafka-connect.yaml 
 ```
@@ -33,16 +34,16 @@ status:
   connectorPlugins:
   - class: io.debezium.connector.mysql.MySqlConnector
     type: source
-    version: 1.5.0.Final
+    version: 1.6.1.Final
   - class: io.debezium.connector.postgresql.PostgresConnector
     type: source
-    version: 1.5.0.Final
+    version: 1.6.1.Final
   - class: org.apache.kafka.connect.file.FileStreamSinkConnector
     type: sink
-    version: 2.7.0.redhat-00005
+    version: 2.8.0.redhat-00002
   - class: org.apache.kafka.connect.file.FileStreamSourceConnector
     type: source
-    version: 2.7.0.redhat-00005
+    version: 2.8.0.redhat-00002
   - class: org.apache.kafka.connect.mirror.MirrorCheckpointConnector
     type: source
     version: "1"

--- a/06-kafka-connect/connectors/file-source-connector.yml
+++ b/06-kafka-connect/connectors/file-source-connector.yml
@@ -1,3 +1,4 @@
+---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaConnector
 metadata:
@@ -12,5 +13,5 @@ spec:
   class: org.apache.kafka.connect.file.FileStreamSourceConnector
   tasksMax: 1
   config:
-    file: "/opt/kafka/LICENSE"
+    file: /opt/kafka/LICENSE
     topic: samples.connect.file-source-topic

--- a/06-kafka-connect/debezium-mysql/mysql-enterprise-source-connector.yaml
+++ b/06-kafka-connect/debezium-mysql/mysql-enterprise-source-connector.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaConnector
 metadata:
@@ -18,8 +19,7 @@ spec:
     database.include.list: enterprise
     database.history.kafka.bootstrap.servers: event-bus-kafka-bootstrap:9092
     database.history.kafka.topic: schema-changes.enterprise
-    include.schema.changes: false
-    #snapshot.mode: schema_only_recovery
+    include.schema.changes: false    
     snapshot.mode: initial
     snapshot.new.tables: parallel
     # To solve offset flush timeouts: The interval should be shortened and timeout increased.

--- a/06-kafka-connect/debezium-mysql/mysql-inventory-source-connector.yaml
+++ b/06-kafka-connect/debezium-mysql/mysql-inventory-source-connector.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaConnector
 metadata:

--- a/06-kafka-connect/eda-kafka-connect.yaml
+++ b/06-kafka-connect/eda-kafka-connect.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: KafkaConnect
 metadata:
@@ -8,7 +9,7 @@ metadata:
     # needing to call the Connect REST API directly
     strimzi.io/use-connector-resources: "true"
 spec:
-  version: 2.7.0
+  version: 2.8.0
   replicas: 1
   bootstrapServers: event-bus-kafka-bootstrap:9092
   config:
@@ -38,28 +39,28 @@ spec:
         artifacts:
           # Debezium Connector for PostgreSQL
           - type: tgz
-            url: https://repo1.maven.org/maven2/io/debezium/debezium-connector-postgres/1.5.0.Final/debezium-connector-postgres-1.5.0.Final-plugin.tar.gz
+            url: https://repo1.maven.org/maven2/io/debezium/debezium-connector-postgres/1.6.1.Final/debezium-connector-postgres-1.6.1.Final-plugin.tar.gz
       # Debezium Connector for MySQL
       - name: debezium-connector-mysql
         artifacts:
           - type: tgz
-            url: https://repo1.maven.org/maven2/io/debezium/debezium-connector-mysql/1.5.0.Final/debezium-connector-mysql-1.5.0.Final-plugin.tar.gz
+            url: https://repo1.maven.org/maven2/io/debezium/debezium-connector-mysql/1.6.1.Final/debezium-connector-mysql-1.6.1.Final-plugin.tar.gz
       # Apicurio Registry Connect Converters
       - name: apicurio-registry-converter
         artifacts:
           - type: tgz
-            url: https://repo1.maven.org/maven2/io/apicurio/apicurio-registry-distro-connect-converter/2.0.0.Final/apicurio-registry-distro-connect-converter-2.0.0.Final.tar.gz
+            url: https://repo1.maven.org/maven2/io/apicurio/apicurio-registry-distro-connect-converter/2.0.1.Final/apicurio-registry-distro-connect-converter-2.0.1.Final.tar.gz
   resources: 
     requests:
       cpu: 500m
       memory: 2Gi
     limits:
-      cpu: "1"
+      cpu: 1
       memory: 2Gi
   logging: 
     type: inline
     loggers:
-      log4j.rootLogger: "INFO"
+      log4j.rootLogger: INFO
   readinessProbe: 
     initialDelaySeconds: 30
     timeoutSeconds: 5

--- a/06-kafka-connect/topics/kafka-connect-cluster-configs-topic.yml
+++ b/06-kafka-connect/topics/kafka-connect-cluster-configs-topic.yml
@@ -4,11 +4,9 @@ kind: KafkaTopic
 metadata:
   labels:
     strimzi.io/cluster: event-bus
-  name: eda.events.alerts
+  name: kafka-connect-cluster-configs
 spec:
   config:
-    retention.ms: 604800000
-    segment.bytes: 1073741824
-    cleanup.policy: delete
+    cleanup.policy: compact
   partitions: 1
   replicas: 3

--- a/06-kafka-connect/topics/kafka-connect-cluster-offsets-topic.yml
+++ b/06-kafka-connect/topics/kafka-connect-cluster-offsets-topic.yml
@@ -4,11 +4,9 @@ kind: KafkaTopic
 metadata:
   labels:
     strimzi.io/cluster: event-bus
-  name: eda.events.alerts
+  name: kafka-connect-cluster-offsets
 spec:
   config:
-    retention.ms: 604800000
-    segment.bytes: 1073741824
-    cleanup.policy: delete
-  partitions: 1
+    cleanup.policy: compact
+  partitions: 25
   replicas: 3

--- a/06-kafka-connect/topics/kafka-connect-cluster-status-topic.yml
+++ b/06-kafka-connect/topics/kafka-connect-cluster-status-topic.yml
@@ -4,11 +4,9 @@ kind: KafkaTopic
 metadata:
   labels:
     strimzi.io/cluster: event-bus
-  name: eda.events.alerts
+  name: kafka-connect-cluster-status
 spec:
   config:
-    retention.ms: 604800000
-    segment.bytes: 1073741824
-    cleanup.policy: delete
+    cleanup.policy: compact
   partitions: 1
   replicas: 3

--- a/08-quarkus-business-app/pom.xml
+++ b/08-quarkus-business-app/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.redhat.banking.enterprise</groupId>
   <artifactId>business-app</artifactId>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>2.1.3-SNAPSHOT</version>
   <properties>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
@@ -14,7 +14,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>2.0.0.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.1.3.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/08-quarkus-business-app/src/main/docker/Dockerfile.jvm
+++ b/08-quarkus-business-app/src/main/docker/Dockerfile.jvm
@@ -21,7 +21,7 @@
 # docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/business-app-jvm
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 
 ARG JAVA_PACKAGE=java-11-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8

--- a/08-quarkus-business-app/src/main/docker/Dockerfile.legacy-jar
+++ b/08-quarkus-business-app/src/main/docker/Dockerfile.legacy-jar
@@ -21,7 +21,7 @@
 # docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/business-app-legacy-jar
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 
 ARG JAVA_PACKAGE=java-11-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8

--- a/08-quarkus-business-app/src/main/docker/Dockerfile.native
+++ b/08-quarkus-business-app/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/business-app
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/09-event-schemas-api/pom.xml
+++ b/09-event-schemas-api/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.redhat.banking.eda</groupId>
     <artifactId>event-schemas-api</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.1.3-SNAPSHOT</version>
     <properties>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
@@ -15,7 +15,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.0.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.1.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>
         <!-- Avro -->

--- a/09-event-schemas-api/src/main/docker/Dockerfile.jvm
+++ b/09-event-schemas-api/src/main/docker/Dockerfile.jvm
@@ -21,7 +21,7 @@
 # docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/quarkus-streaming-jvm
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 
 ARG JAVA_PACKAGE=java-11-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8

--- a/09-event-schemas-api/src/main/docker/Dockerfile.legacy-jar
+++ b/09-event-schemas-api/src/main/docker/Dockerfile.legacy-jar
@@ -21,7 +21,7 @@
 # docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/quarkus-streaming-legacy-jar
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 
 ARG JAVA_PACKAGE=java-11-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8

--- a/09-event-schemas-api/src/main/docker/Dockerfile.native
+++ b/09-event-schemas-api/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/quarkus-streaming
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/10-quarkus-streaming/pom.xml
+++ b/10-quarkus-streaming/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.redhat.banking.eda</groupId>
     <artifactId>data-streaming</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.1.3-SNAPSHOT</version>
     <properties>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
@@ -13,10 +13,10 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus-plugin.version>2.0.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>2.1.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.0.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.1.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>
         <!-- Avro -->

--- a/10-quarkus-streaming/src/main/docker/Dockerfile.jvm
+++ b/10-quarkus-streaming/src/main/docker/Dockerfile.jvm
@@ -21,7 +21,7 @@
 # docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/quarkus-streaming-jvm
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 
 ARG JAVA_PACKAGE=java-11-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8

--- a/10-quarkus-streaming/src/main/docker/Dockerfile.legacy-jar
+++ b/10-quarkus-streaming/src/main/docker/Dockerfile.legacy-jar
@@ -21,7 +21,7 @@
 # docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/quarkus-streaming-legacy-jar
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 
 ARG JAVA_PACKAGE=java-11-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8

--- a/10-quarkus-streaming/src/main/docker/Dockerfile.native
+++ b/10-quarkus-streaming/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/quarkus-streaming
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/11-quarkus-backend/pom.xml
+++ b/11-quarkus-backend/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.redhat.banking.eda</groupId>
     <artifactId>backend</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.1.3-SNAPSHOT</version>
     <properties>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
@@ -13,10 +13,10 @@
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus-plugin.version>2.0.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>2.1.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.0.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.1.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>
         <!-- Avro -->

--- a/11-quarkus-backend/src/main/docker/Dockerfile.jvm
+++ b/11-quarkus-backend/src/main/docker/Dockerfile.jvm
@@ -21,7 +21,7 @@
 # docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/backend-jvm
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 
 ARG JAVA_PACKAGE=java-11-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8

--- a/11-quarkus-backend/src/main/docker/Dockerfile.legacy-jar
+++ b/11-quarkus-backend/src/main/docker/Dockerfile.legacy-jar
@@ -21,7 +21,7 @@
 # docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/backend-legacy-jar
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 
 ARG JAVA_PACKAGE=java-11-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8

--- a/11-quarkus-backend/src/main/docker/Dockerfile.native
+++ b/11-quarkus-backend/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/backend
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/12-quarkus-dashboard/pom.xml
+++ b/12-quarkus-dashboard/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.redhat.banking.eda.dashboard</groupId>
     <artifactId>dashboard</artifactId>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.1.3-SNAPSHOT</version>
     <properties>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
@@ -14,10 +14,10 @@
         <node.version>v14.17.0</node.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <quarkus-plugin.version>2.0.0.Final</quarkus-plugin.version>
+        <quarkus-plugin.version>2.1.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus.platform.version>2.0.0.Final</quarkus.platform.version>
+        <quarkus.platform.version>2.1.3.Final</quarkus.platform.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>
         <org.testcontainers.version>1.15.3</org.testcontainers.version>

--- a/12-quarkus-dashboard/src/main/docker/Dockerfile.jvm
+++ b/12-quarkus-dashboard/src/main/docker/Dockerfile.jvm
@@ -21,7 +21,7 @@
 # docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/dashboard-jvm
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 
 ARG JAVA_PACKAGE=java-11-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8

--- a/12-quarkus-dashboard/src/main/docker/Dockerfile.legacy-jar
+++ b/12-quarkus-dashboard/src/main/docker/Dockerfile.legacy-jar
@@ -21,7 +21,7 @@
 # docker run -i --rm -p 8080:8080 -p 5005:5005 -e JAVA_ENABLE_DEBUG="true" quarkus/dashboard-legacy-jar
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3 
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 
 ARG JAVA_PACKAGE=java-11-openjdk-headless
 ARG RUN_JAVA_VERSION=1.3.8

--- a/12-quarkus-dashboard/src/main/docker/Dockerfile.native
+++ b/12-quarkus-dashboard/src/main/docker/Dockerfile.native
@@ -14,7 +14,7 @@
 # docker run -i --rm -p 8080:8080 quarkus/dashboard
 #
 ###
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
 WORKDIR /work/
 RUN chown 1001 /work \
     && chmod "g+rwX" /work \

--- a/14-serverless/README.md
+++ b/14-serverless/README.md
@@ -100,7 +100,7 @@ v0.21-kafka-storage-version-migration-tl687   0/1     Completed   0          31s
 Deploy sample KafkaTopic for testing proposal:
 
 ```shell
-oc apply -f knative-eventing/knative-kafka/topics
+oc apply -f knative-eventing/topics
 ```
 
 ## Deploying Application Serverless Services

--- a/14-serverless/service/backend-service.yaml
+++ b/14-serverless/service/backend-service.yaml
@@ -3,6 +3,9 @@ apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: backend-serverless
+  labels:
+    app.kubernetes.io/instance: data-streaming-serverless
+    app.kubernetes.io/part-of: eda-workshop  
 spec:
   template:
     metadata:
@@ -15,7 +18,7 @@ spec:
         app.kubernetes.io/part-of: eda-workshop
     spec:
       containers:
-        - image: image-registry.openshift-image-registry.svc:5000/eda-workshop/backend:latest
+        - image: image-registry.openshift-image-registry.svc:5000/eda-workshop/backend:2.1.3-SNAPSHOT
           resources:
             requests:
               cpu: 500m

--- a/14-serverless/service/dashboard-service.yaml
+++ b/14-serverless/service/dashboard-service.yaml
@@ -3,6 +3,9 @@ apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: dashboard-serverless
+  labels:
+    app.kubernetes.io/instance: data-streaming-serverless
+    app.kubernetes.io/part-of: eda-workshop  
 spec:
   template:
     metadata:
@@ -11,7 +14,7 @@ spec:
         app.kubernetes.io/part-of: eda-workshop
     spec:
       containers:
-        - image: image-registry.openshift-image-registry.svc:5000/eda-workshop/dashboard:latest
+        - image: image-registry.openshift-image-registry.svc:5000/eda-workshop/dashboard:2.1.3-SNAPSHOT
           resources:
             requests:
               cpu: 500m

--- a/14-serverless/service/data-streaming-service.yaml
+++ b/14-serverless/service/data-streaming-service.yaml
@@ -32,7 +32,7 @@ spec:
         app.kubernetes.io/part-of: eda-workshop
     spec:
       containers:
-        - image: image-registry.openshift-image-registry.svc:5000/eda-workshop/data-streaming:latest
+        - image: image-registry.openshift-image-registry.svc:5000/eda-workshop/data-streaming:2.1.3-SNAPSHOT
           resources:
             requests:
               cpu: 500m

--- a/15-native-services/knative-eventing/kafka-source/backend-native-kafka-source.yaml
+++ b/15-native-services/knative-eventing/kafka-source/backend-native-kafka-source.yaml
@@ -3,7 +3,7 @@ kind: KafkaSource
 metadata:
   name: backend-native-kafka-source
   labels:
-    app.kubernetes.io/part-of: eda-workshop
+    app.kubernetes.io/part-of: eda-workshop-native
     kafkasources.sources.knative.dev/key-type: int
 spec:
   consumerGroup: backend-native-knative-group

--- a/15-native-services/knative-eventing/kafka-source/data-streaming-native-kafka-source.yaml
+++ b/15-native-services/knative-eventing/kafka-source/data-streaming-native-kafka-source.yaml
@@ -3,7 +3,7 @@ kind: KafkaSource
 metadata:
   name: data-streaming-native-kafka-source
   labels:
-    app.kubernetes.io/part-of: eda-workshop
+    app.kubernetes.io/part-of: eda-workshop-native
     kafkasources.sources.knative.dev/key-type: string
 spec:
   consumerGroup: data-streaming-native-knative-group

--- a/15-native-services/service/backend-native-service.yaml
+++ b/15-native-services/service/backend-native-service.yaml
@@ -5,7 +5,7 @@ metadata:
   name: backend-native-serverless
   labels:
     app.kubernetes.io/instance: backend-native-serverless
-    app.kubernetes.io/part-of: eda-workshop
+    app.kubernetes.io/part-of: eda-workshop-native
 spec:
   template:
     metadata:
@@ -15,10 +15,10 @@ spec:
         autoscaling.knative.dev/scaleToZeroPodRetentionPeriod: "5s"
       labels:
         app.kubernetes.io/instance: backend-native-serverless
-        app.kubernetes.io/part-of: eda-workshop
+        app.kubernetes.io/part-of: eda-workshop-native
     spec:
       containers:
-        - image: quay.io/eda-workshop/backend:2.0.0-SNAPSHOT
+        - image: quay.io/eda-workshop/backend:2.1.3-SNAPSHOT
           resources:
             requests:
               cpu: 500m

--- a/15-native-services/service/dashboard-native-service.yaml
+++ b/15-native-services/service/dashboard-native-service.yaml
@@ -5,16 +5,16 @@ metadata:
   name: dashboard-native-serverless
   labels:
     app.kubernetes.io/instance: dashboard-native-serverless
-    app.kubernetes.io/part-of: eda-workshop
+    app.kubernetes.io/part-of: eda-workshop-native
 spec:
   template:
     metadata:
       labels:
         app.kubernetes.io/instance: dashboard-native-serverless
-        app.kubernetes.io/part-of: eda-workshop
+        app.kubernetes.io/part-of: eda-workshop-native
     spec:
       containers:
-        - image: quay.io/eda-workshop/dashboard:2.0.0-SNAPSHOT
+        - image: quay.io/eda-workshop/dashboard:2.1.3-SNAPSHOT
           resources:
             requests:
               cpu: 500m

--- a/15-native-services/service/data-streaming-native-service.yaml
+++ b/15-native-services/service/data-streaming-native-service.yaml
@@ -5,7 +5,7 @@ metadata:
   name: data-streaming-native-serverless
   labels:
     app.kubernetes.io/instance: data-streaming-native-serverless
-    app.kubernetes.io/part-of: eda-workshop  
+    app.kubernetes.io/part-of: eda-workshop-native
 spec:
   template:
     metadata:
@@ -29,10 +29,10 @@ spec:
         #autoscaling.knative.dev/target: "50"
       labels:
         app.kubernetes.io/instance: data-streaming-native-serverless
-        app.kubernetes.io/part-of: eda-workshop
+        app.kubernetes.io/part-of: eda-workshop-native
     spec:
       containers:
-        - image: quay.io/eda-workshop/data-streaming:2.0.0-SNAPSHOT
+        - image: quay.io/eda-workshop/data-streaming:2.1.3-SNAPSHOT
           resources:
             requests:
               cpu: 500m

--- a/README.md
+++ b/README.md
@@ -33,7 +33,15 @@ the root of this repository.
 
 ## Prepare OpenShift
 
-This architecture has been tested in Red Hat OpenShift Container Platform 4.7 version.
+This architecture has been tested in Red Hat OpenShift Container Platform 4.8 version and the following
+operators:
+
+* Red Hat Integration - AMQ Streams 1.8.0
+* Red Hat Integration - Service Registry 2.0.1
+* Red Hat Data Grid 8.2.3
+* Red Hat OpenShift Serverless 1.16.0
+* Prometheus 0.47.0
+* Grafana 3.10.3
 
 As a normal user in your OpenShift cluster, create a ```eda-workshop``` namespace:
 
@@ -45,7 +53,8 @@ As a normal user in your OpenShift cluster, create a ```eda-workshop``` namespac
 This workshop requires deploy many different components and
 it is needed to have enough resources. This workshop was
 tested in "OpenShift 4.7 Workshop (Small)" Service provided
-in the [Red Hat Product Demo System](https://rhpds.redhat.com/) with a single worker node of AWS instance type `m5a.4xlarge`. Other node topologies and types should work.
+in the [Red Hat Product Demo System](https://rhpds.redhat.com/) with a single worker node of AWS
+instance type `m5a.4xlarge`. Other node topologies and types should work.
 
 ## Deploy Operators
 


### PR DESCRIPTION
Adding new changes to improve this workshop. Summary of changes:

:memo: New changes
:rocket: Updating deployment scripts
:art: Defining new application name for native version
:bookmark: Fixed new Application version
:arrow_up: Upgrade to Quarkus 2.1.3
:arrow_up: Upgrade to Service Registry Operator 2.0.1
:arrow_up: Upgrade to Serverles Operator 1.16.0
:arrow_up: Upgrade to DataGrid Operator 8.2.3
:arrow_up: Upgrade to AMQ Streams 1.8.0 and Debezium 1.6.1